### PR TITLE
Add insider risk API foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Available routes:
 - `GET /api/v1/alerts/active`
 - `GET /api/v1/events/recent`
 - `GET /api/v1/detections/summary`
+- `GET /api/v1/insider-risk`
 
 Set `DATABASE_URL` for DB-backed routes.
 

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -50,6 +50,26 @@ CREATE TABLE IF NOT EXISTS alerts (
 CREATE INDEX IF NOT EXISTS idx_alerts_status_time
 ON alerts (status, triggered_at DESC);
 
+CREATE TABLE IF NOT EXISTS insider_risk_findings (
+    id BIGSERIAL PRIMARY KEY,
+    symbol VARCHAR(20) NOT NULL,
+    risk_score NUMERIC(5,2) NOT NULL CHECK (risk_score >= 0 AND risk_score <= 100),
+    severity VARCHAR(10) NOT NULL CHECK (severity IN ('P1','P2','P3','P4')),
+    affected_user VARCHAR(255),
+    source_ip INET,
+    market_signal VARCHAR(100),
+    related_event_count INT NOT NULL DEFAULT 0 CHECK (related_event_count >= 0),
+    reason TEXT NOT NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'OPEN' CHECK (status IN ('OPEN','ACK','RESOLVED','FP')),
+    detected_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_insider_risk_status_time
+ON insider_risk_findings (status, detected_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_insider_risk_symbol_time
+ON insider_risk_findings (symbol, detected_at DESC);
+
 CREATE TABLE IF NOT EXISTS incidents (
     id BIGSERIAL PRIMARY KEY,
     incident_code VARCHAR(40) NOT NULL UNIQUE,

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -8,6 +8,7 @@ from src.api.schemas import (
     ActiveAlertsResponse,
     AlertSummaryResponse,
     HealthResponse,
+    InsiderRiskResponse,
     MarketLatestResponse,
     SecurityEventsResponse,
 )
@@ -145,3 +146,38 @@ def detection_summary() -> AlertSummaryResponse:
         ) from exc
 
     return AlertSummaryResponse(database_configured=True, items=rows)
+
+
+@app.get("/api/v1/insider-risk", response_model=InsiderRiskResponse, tags=["risk"])
+def insider_risk_findings(limit: int = 50) -> InsiderRiskResponse:
+    safe_limit = max(1, min(limit, 200))
+    query = """
+        SELECT
+            id,
+            symbol,
+            risk_score,
+            severity,
+            affected_user,
+            source_ip::text AS source_ip,
+            market_signal,
+            related_event_count,
+            reason,
+            status,
+            detected_at
+        FROM insider_risk_findings
+        WHERE status IN ('OPEN', 'ACK')
+        ORDER BY detected_at DESC
+        LIMIT %s
+    """
+
+    try:
+        rows = fetch_all(query, (safe_limit,))
+    except DatabaseUnavailable:
+        return InsiderRiskResponse(database_configured=False, items=[])
+    except Exception as exc:
+        raise HTTPException(
+            status_code=500,
+            detail="Failed to load insider risk findings",
+        ) from exc
+
+    return InsiderRiskResponse(database_configured=True, items=rows)

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -72,3 +72,24 @@ class AlertSummaryItem(BaseModel):
 class AlertSummaryResponse(BaseModel):
     database_configured: bool
     items: list[AlertSummaryItem]
+
+
+class InsiderRiskFinding(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    symbol: str
+    risk_score: Decimal
+    severity: str
+    affected_user: str | None = None
+    source_ip: str | None = None
+    market_signal: str | None = None
+    related_event_count: int
+    reason: str
+    status: str
+    detected_at: datetime
+
+
+class InsiderRiskResponse(BaseModel):
+    database_configured: bool
+    items: list[InsiderRiskFinding]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -65,6 +65,15 @@ class ApiRoutesTestCase(unittest.TestCase):
             {"database_configured": False, "items": []},
         )
 
+    def test_insider_risk_returns_empty_state_without_database(self) -> None:
+        response = self.client.get("/api/v1/insider-risk")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {"database_configured": False, "items": []},
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Summary: add insider_risk_findings schema, InsiderRisk API schemas, GET /api/v1/insider-risk, README route docs, and empty-state API smoke coverage. Tests: pytest -q tests; unittest discover -s tests -v; import src.api.dashboard. Closes #31.