### PR TITLE
Create AWS app host runtime for persistent live demo

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.github
+.venv
+__pycache__
+*.pyc
+.pytest_cache
+.terraform
+terraform/**/*.tfstate
+terraform/**/*.tfstate.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.13-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8000 8501

--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ Expected output fields include:
 python3 -m pytest -q tests/test_detection_engine.py tests/test_api.py
 ```
 
+## Live Demo Deployment
+
+See `docs/live-demo-aws.md` for the EC2, Docker Compose, Nginx, and RDS-backed
+demo runbook.
+
 ## Current Progress
 
 ### Completed

--- a/deploy/nginx/quantshield.conf.example
+++ b/deploy/nginx/quantshield.conf.example
@@ -1,0 +1,26 @@
+server {
+    listen 80;
+    server_name demo.example.com;
+
+    location / {
+        proxy_pass http://127.0.0.1:8501;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+
+server {
+    listen 80;
+    server_name api.example.com;
+
+    location / {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/deploy/systemd/quantshield-demo.service
+++ b/deploy/systemd/quantshield-demo.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=QuantShield live demo stack
+Requires=docker.service
+After=docker.service network-online.target
+
+[Service]
+Type=oneshot
+WorkingDirectory=/opt/quantshield
+RemainAfterExit=yes
+ExecStart=/usr/bin/docker compose up -d --build
+ExecStop=/usr/bin/docker compose down
+TimeoutStartSec=0
+
+[Install]
+WantedBy=multi-user.target

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+services:
+  api:
+    build:
+      context: .
+    command: uvicorn src.api.main:app --host 0.0.0.0 --port 8000
+    environment:
+      DATABASE_URL: ${DATABASE_URL:-}
+    ports:
+      - "8000:8000"
+    restart: unless-stopped
+
+  dashboard:
+    build:
+      context: .
+    command: streamlit run src/api/dashboard.py --server.address 0.0.0.0 --server.port 8501
+    environment:
+      DATABASE_URL: ${DATABASE_URL:-}
+      QUANTSHIELD_API_URL: ${QUANTSHIELD_API_URL:-http://api:8000}
+    ports:
+      - "8501:8501"
+    restart: unless-stopped
+    depends_on:
+      - api

--- a/docs/live-demo-aws.md
+++ b/docs/live-demo-aws.md
@@ -1,0 +1,105 @@
+# QuantShield Live Demo AWS Runbook
+
+## Target Architecture
+
+```text
+Internet
+  |
+  v
+Public EC2 app host
+  |-- Nginx
+  |-- Docker Compose
+  |-- FastAPI service on 8000
+  |-- Streamlit dashboard on 8501
+  |
+  v
+RDS PostgreSQL
+```
+
+Keep the v1 demo under control by avoiding NAT Gateway, ALB, autoscaling, and
+Kubernetes. One small public app host plus RDS is enough for a portfolio demo.
+
+## Host Setup
+
+Install packages on the app host:
+
+```bash
+sudo dnf update -y
+sudo dnf install -y git nginx docker
+sudo systemctl enable --now docker nginx
+sudo usermod -aG docker ec2-user
+```
+
+Install Docker Compose if it is not already available as `docker compose`.
+
+Clone the repo:
+
+```bash
+sudo mkdir -p /opt/quantshield
+sudo chown ec2-user:ec2-user /opt/quantshield
+git clone https://github.com/RyanMFurman/quantshield.git /opt/quantshield
+cd /opt/quantshield
+```
+
+Create the app environment:
+
+```bash
+cp .env.example .env
+```
+
+Set:
+
+```text
+DATABASE_URL=postgresql://...
+QUANTSHIELD_API_URL=https://api.example.com
+```
+
+## Run App Stack
+
+```bash
+docker compose up -d --build
+curl http://127.0.0.1:8000/health
+```
+
+Install the systemd unit:
+
+```bash
+sudo cp deploy/systemd/quantshield-demo.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now quantshield-demo
+```
+
+## Nginx
+
+Copy the example config:
+
+```bash
+sudo cp deploy/nginx/quantshield.conf.example /etc/nginx/conf.d/quantshield.conf
+sudo nginx -t
+sudo systemctl reload nginx
+```
+
+Replace:
+
+```text
+demo.example.com
+api.example.com
+```
+
+with the final public DNS names.
+
+## Seed Demo Data
+
+After the schema exists and `DATABASE_URL` is set:
+
+```bash
+docker compose exec api python scripts/seed_live_demo_data.py
+```
+
+Verify:
+
+```bash
+curl http://127.0.0.1:8000/market/latest
+curl http://127.0.0.1:8000/alerts/active
+curl http://127.0.0.1:8000/api/v1/insider-risk
+```


### PR DESCRIPTION
Summary: add Dockerfile, Docker Compose API/dashboard services, environment example, Nginx proxy example, systemd unit, and AWS EC2 live demo runbook. This avoids NAT Gateway and load balancer cost for the v1 portfolio demo. Tests: pytest -q tests; unittest discover -s tests -v; docker compose config. Closes #34.