### PR TITLE
Add scheduled demo data refresh and detection runner

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "src/**"
+      - "scripts/**"
       - "tests/**"
       - "requirements.txt"
       - "README.md"
@@ -14,6 +15,7 @@ on:
       - "feature/**"
     paths:
       - "src/**"
+      - "scripts/**"
       - "tests/**"
       - "requirements.txt"
       - "README.md"

--- a/deploy/systemd/quantshield-demo-refresh.service
+++ b/deploy/systemd/quantshield-demo-refresh.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Refresh QuantShield demo data and detections
+Requires=docker.service
+After=docker.service quantshield-demo.service
+
+[Service]
+Type=oneshot
+WorkingDirectory=/opt/quantshield
+ExecStart=/usr/bin/docker compose exec -T api python scripts/seed_live_demo_data.py

--- a/deploy/systemd/quantshield-demo-refresh.timer
+++ b/deploy/systemd/quantshield-demo-refresh.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run QuantShield demo data refresh every 15 minutes
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=15min
+Unit=quantshield-demo-refresh.service
+
+[Install]
+WantedBy=timers.target

--- a/docs/live-demo-aws.md
+++ b/docs/live-demo-aws.md
@@ -103,3 +103,27 @@ curl http://127.0.0.1:8000/market/latest
 curl http://127.0.0.1:8000/alerts/active
 curl http://127.0.0.1:8000/api/v1/insider-risk
 ```
+
+## Scheduled Refresh
+
+Install the refresh service and timer:
+
+```bash
+sudo cp deploy/systemd/quantshield-demo-refresh.service /etc/systemd/system/
+sudo cp deploy/systemd/quantshield-demo-refresh.timer /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now quantshield-demo-refresh.timer
+```
+
+Run the refresh manually:
+
+```bash
+sudo systemctl start quantshield-demo-refresh.service
+```
+
+Check status and logs:
+
+```bash
+systemctl status quantshield-demo-refresh.timer
+journalctl -u quantshield-demo-refresh.service -n 100 --no-pager
+```

--- a/scripts/seed_live_demo_data.py
+++ b/scripts/seed_live_demo_data.py
@@ -118,6 +118,22 @@ def seed_demo_data(db_url: str) -> dict[str, int]:
 
     with psycopg.connect(db_url) as conn:
         with conn.cursor() as cur:
+            cur.execute(
+                """
+                DELETE FROM market_prices
+                WHERE symbol = ANY(%s)
+                  AND captured_at < NOW() - INTERVAL '2 hours'
+                """,
+                ([row[0] for row in MARKET_ROWS],),
+            )
+            cur.execute(
+                """
+                DELETE FROM insider_risk_findings
+                WHERE symbol = 'NVDA'
+                  AND status IN ('OPEN', 'ACK')
+                  AND reason LIKE 'NVDA showed%%'
+                """
+            )
             cur.executemany(
                 """
                 INSERT INTO market_prices (symbol, price, volume, prev_close, captured_at)


### PR DESCRIPTION
Summary: add systemd service and timer to refresh demo data every 15 minutes through Docker Compose, document manual/scheduled refresh commands, and prune old demo rows/open NVDA demo findings during refresh. Tests: pytest -q tests; unittest discover -s tests -v; import seed script and dashboard. Closes #37.