### PR TITLE
Add HTTPS and public URLs for live demo

### DIFF
--- a/deploy/nginx/quantshield.conf.example
+++ b/deploy/nginx/quantshield.conf.example
@@ -2,6 +2,35 @@ server {
     listen 80;
     server_name demo.example.com;
 
+    location /.well-known/acme-challenge/ {
+        root /var/www/html;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 80;
+    server_name api.example.com;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/html;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl;
+    server_name demo.example.com;
+
+    ssl_certificate /etc/letsencrypt/live/demo.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/demo.example.com/privkey.pem;
+
     location / {
         proxy_pass http://127.0.0.1:8501;
         proxy_http_version 1.1;
@@ -14,8 +43,11 @@ server {
 }
 
 server {
-    listen 80;
+    listen 443 ssl;
     server_name api.example.com;
+
+    ssl_certificate /etc/letsencrypt/live/api.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/api.example.com/privkey.pem;
 
     location / {
         proxy_pass http://127.0.0.1:8000;

--- a/docs/live-demo-aws.md
+++ b/docs/live-demo-aws.md
@@ -91,6 +91,44 @@ api.example.com
 
 with the final public DNS names.
 
+## HTTPS
+
+Point DNS records at the app host public IP before requesting certificates:
+
+```text
+demo.example.com -> app host public IP
+api.example.com  -> app host public IP
+```
+
+Install Certbot:
+
+```bash
+sudo dnf install -y certbot
+```
+
+Stop Nginx and request certificates with the standalone challenge:
+
+```bash
+sudo systemctl stop nginx
+sudo certbot certonly --standalone -d demo.example.com
+sudo certbot certonly --standalone -d api.example.com
+sudo systemctl start nginx
+```
+
+After certificates exist, copy `deploy/nginx/quantshield.conf.example`, replace
+the example domains, and reload Nginx:
+
+```bash
+sudo nginx -t
+sudo systemctl reload nginx
+```
+
+Verify renewal:
+
+```bash
+sudo certbot renew --dry-run
+```
+
 ## Seed Demo Data
 
 After the schema exists and `DATABASE_URL` is set:


### PR DESCRIPTION
Summary: update Nginx example for HTTPS public dashboard/API URLs and document DNS, Certbot certificate issuance, Nginx reload, and renewal verification. Tests: pytest -q tests; unittest discover -s tests -v. Closes #36.